### PR TITLE
Sloppy CFVs calculation on flop/turn

### DIFF
--- a/csrc/src/main_bot.cpp
+++ b/csrc/src/main_bot.cpp
@@ -87,15 +87,9 @@ Action MainBot::get_action(const GameInfo& game_info, const RoundStatePtr& state
     return Action{state->legal_actions().front()};
   }
 
-  // TODO cant afford to do CFR on flop/turn for now
-  if (state->round() == round::FLOP || state->round() == round::TURN) {
-    if (ranges::contains(legal_actions, Action::Type::CHECK)) {
-      return {Action::Type::CHECK};
-    }
-    return {Action::Type::CALL};
-  }
-
   // Solve..
+  // FIXME - On flop/turn, CFVs are calculated as if showdown will be held with the current board
+  // (i.e., no more chance cards are dealt)
   const auto time_budget_ms = time_manager_.time_ms_allowed_for_cfr(game_info);
   fmt::print("{:.2f} ms allocated for solving with CFR \n", time_budget_ms);
   cfr_.solve(ranges_, state, active, time_budget_ms);

--- a/csrc/src/main_bot_test.cpp
+++ b/csrc/src/main_bot_test.cpp
@@ -30,9 +30,11 @@ TEST(MainBotTest, TestFlopState) {
   MainBot bot;
 
   GameInfo game_info(0, 10.0, 1000);
-  std::array<std::string, 2> empty_hand = {"4c4d", ""};
+  std::array<std::string, 2> empty_hand = {"4c4d5c", ""};
+
+  std::array<std::optional<int>, 2> bids = {0, 0};
   const auto board_cards = Card::to_vector("2c2d2h");
-  StatePtr round_state = std::make_shared<RoundState>(0, false, NO_BIDS, NO_BETS, STARTING_STACKS,
+  StatePtr round_state = std::make_shared<RoundState>(0, false, bids, NO_BETS, STARTING_STACKS,
                                                       empty_hand, board_cards, nullptr);
 
   auto action =
@@ -45,9 +47,11 @@ TEST(MainBotTest, TestTurnState) {
   MainBot bot;
 
   GameInfo game_info(0, 10.0, 1000);
-  std::array<std::string, 2> empty_hand = {"4c4d", ""};
+  std::array<std::string, 2> empty_hand = {"4c4d5c", ""};
+
+  std::array<std::optional<int>, 2> bids = {0, 0};
   const auto board_cards = Card::to_vector("2c2d2h2s");
-  StatePtr round_state = std::make_shared<RoundState>(0, false, NO_BIDS, NO_BETS, STARTING_STACKS,
+  StatePtr round_state = std::make_shared<RoundState>(0, false, bids, NO_BETS, STARTING_STACKS,
                                                       empty_hand, board_cards, nullptr);
 
   auto action =


### PR DESCRIPTION
This is a very sloppy hack, but this PR calculates CFVs on flop/turn as if the showdown will be held with the current board, without remaining rounds. I think this is a good prototype, and it beats the bid-everything bot!